### PR TITLE
Add error message for screen capture permission error on mac

### DIFF
--- a/src/platform/macos/capturable_content.rs
+++ b/src/platform/macos/capturable_content.rs
@@ -8,6 +8,8 @@ use crate::{capturable_content::{CapturableContentError, CapturableContentFilter
 
 use super::objc_wrap::{get_window_description, get_window_levels, CGMainDisplayID, CGWindowID, SCDisplay, SCRunningApplication, SCShareableContent, SCWindow};
 
+const SC_PERMISSION_DENIED_ERROR_CODE: isize = -3801;
+
 pub struct MacosCapturableContent {
     pub windows: Vec<SCWindow>,
     pub excluding_windows: Vec<SCWindow>,
@@ -48,9 +50,12 @@ impl MacosCapturableContent {
                 })
             },
             Ok(Err(error)) => {
+                if error.code() == SC_PERMISSION_DENIED_ERROR_CODE {
+                    return Err(CapturableContentError::Other("SCShareableContent error: Permission to screen capture was denied".to_string()))
+                }
                 Err(CapturableContentError::Other(format!("SCShareableContent returned error code: {}", error.code())))
             }
-            Err(error) => Err(CapturableContentError::Other(format!("Failed to receive SCSharableContent result from completion handler future: {}", error.to_string()))),
+            Err(error) => Err(CapturableContentError::Other(format!("Failed to receive SCSharableContent result from completion handler future: {}", error))),
         }
     }
 }


### PR DESCRIPTION
In case of running `CapturableContent::new()` without screen capture permission on mac.

Earlier:
<img width="1039" alt="Screenshot 2024-12-16 at 4 41 22 PM" src="https://github.com/user-attachments/assets/580ddfa4-e7eb-4d4c-b8a3-013c0d0173e7" />

Now:
<img width="1308" alt="Screenshot 2024-12-16 at 4 40 32 PM" src="https://github.com/user-attachments/assets/1706ca0a-531f-4de9-a972-73cc76ca0662" />
