### PR TITLE
fix: prevent segfaults while extracting NSString

### DIFF
--- a/src/platform/macos/objc_wrap.rs
+++ b/src/platform/macos/objc_wrap.rs
@@ -309,8 +309,12 @@ impl NSString {
 
     pub(crate) fn from_id_unretained(id: *mut AnyObject) -> Self {
         unsafe {
-            let _: *mut AnyObject = msg_send![id, retain];
-            Self(id)
+            if (id as *const AnyObject).is_null() {
+                Self::new("")
+            } else {
+                let _: *mut AnyObject = msg_send![id, retain];
+                Self(id)
+            }
         }
     }
 


### PR DESCRIPTION
## Why do we need this change?
Trying to get the NSString for a NULL address results in a SEGFAULT causing app crash and bugs. For instance, I was able to consistently reproduce this when trying to get all capturable windows using the `EVERYTHING` CapturableContentFilter.

## How do we do this change?
We check if the pointer is null, and only get the actual string if it is not. If the pointer is NULL, we return an empty string for now.